### PR TITLE
Build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ ehthumbs.db
 Thumbs.db
 .idea
 */target/**
+/Makefile.local

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ SHELL             := bash
 .SUFFIXES:
 
 # Constants, these can be overwritten in your Makefile.local
-CONTAINER := magneticio/buildserver:latest
+CONTAINER     := magneticio/buildserver:latest
+DOCKER_BINARY := docker
 
 # if Makefile.local exists, include it.
 ifneq ("$(wildcard Makefile.local)", "")
@@ -25,7 +26,7 @@ default:
 		--rm \
 		-e VAMP_GIT_BRANCH=${VAMP_GIT_BRANCH} \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
-		--volume $(shell command -v docker):/usr/bin/docker \
+		--volume $(shell command -v $(DOCKER_BINARY)):/usr/bin/docker \
 		--volume $(CURDIR):/srv/src \
 		--volume $(HOME)/.sbt:/root/.sbt \
 		--volume $(HOME)/.ivy2:/root/.ivy2 \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: default
 
 # Using our buildserver which contains all the necessary dependencies
 .PHONY: default
-default:
+default: clean-check
 	docker pull $(BUILD_SERVER)
 	docker run \
 		--name buildrunner \
@@ -45,3 +45,20 @@ default:
 .PHONY: build
 build:
 	./build.sh --build
+
+.PHONY: clean
+clean:
+	rm -rf target project/project project/target
+	rm -rf ui/node_modules
+
+.PHONY: clean-check
+clean-check:
+	if [ $$(find -uid 0 -print -quit | wc -l) -eq 1 ]; then \
+		docker run \
+		--name buildrunner \
+		--rm \
+		--volume $(CURDIR):/srv/src \
+		--workdir=/srv/src \
+		$(BUILD_SERVER) \
+			make clean; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ SHELL             := bash
 .SUFFIXES:
 
 # Constants, these can be overwritten in your Makefile.local
-CONTAINER     := magneticio/buildserver:latest
+BUILD_SERVER     := magneticio/buildserver:latest
+DIR_SBT       := $(HOME)/.sbt/boot
+DIR_IVY       := $(HOME)/.ivy2
+DIR_NPM       := $(HOME)/.npm
+DIR_GYP       := $(HOME)/.node-gyp
 DOCKER_BINARY := docker
 
 # if Makefile.local exists, include it.
@@ -21,25 +25,23 @@ all: default
 # Using our buildserver which contains all the necessary dependencies
 .PHONY: default
 default:
-	docker pull $(CONTAINER)
+	docker pull $(BUILD_SERVER)
 	docker run \
+		--name buildrunner \
 		--rm \
-		-e VAMP_GIT_BRANCH=${VAMP_GIT_BRANCH} \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--volume $(shell command -v $(DOCKER_BINARY)):/usr/bin/docker \
+		--volume $(DIR_SBT):/home/vamp/.sbt/boot \
+		--volume $(DIR_IVY):/home/vamp/.ivy2 \
+		--volume $(DIR_NPM):/home/vamp/.npm \
+		--volume $(DIR_GYP):/home/vamp/.node-gyp \
 		--volume $(CURDIR):/srv/src \
-		--volume $(HOME)/.sbt:/root/.sbt \
-		--volume $(HOME)/.ivy2:/root/.ivy2 \
 		--workdir=/srv/src \
-		$(CONTAINER) \
-			make build
-
+		--env BUILD_UID=$(shell id -u) \
+		--env BUILD_GID=$(shell stat -c '%g' /var/run/docker.sock) \
+		$(BUILD_SERVER) \
+			make VAMP_GIT_BRANCH=${VAMP_GIT_BRANCH} build
 
 .PHONY: build
 build:
 	./build.sh --build
-
-
-.PHONY: clean
-clean:
-	./build.sh --remove

--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ function gulp_make {
     rm -Rf bower_components node_modules dist ui ui.tar.bz2 2> /dev/null
 
     npm install
-    ng build --env=prod
+    npm run ng -- build --env=prod
 
     mv dist ui && tar -cvjSf ui.tar.bz2 ui
     rm -Rf ui 2> /dev/null && mv ui.tar.bz2 ${target_docker}/


### PR DESCRIPTION
changes:
- the CONTAINER was changed to the one used by the rest of the projects (so that a single Makefile.local can be easily used)
- the buildserver container is run with access to the user's cache for node and scala packages
- the docker command that is shared with the buildserver container is customizable (e.g. CentOS has a wrapper script as docker which selects between a -current and a -latest binary)
- the user id and is set to the one of the user, so that the user can easily clean-up after the build
  while the group id is is set to the group of the docker socket file so that the container can access it even without root access
- the clean is removed because it is not actually implemented
- the build.sh calls ng indirectly so that it can easily be run from outside the buildserver image without relying on the users' PATH